### PR TITLE
feature_issue_2_gau_fix

### DIFF
--- a/controllers/webhook-controller.js
+++ b/controllers/webhook-controller.js
@@ -70,6 +70,7 @@ routerWHC.post('/' + shared.bePath + '/webhook', function (req, res) {
       headers: {
         'Content-Type': 'application/json',
         'Accept': 'application/json',
+        'X-ORIG-SERVER': req.host,
         'Authorization': token
       },
       json: req.body


### PR DESCRIPTION
Keeping original server name in the special header in order to use it in WHS to generate correct webhook URL, i.e., do not use internal host names in the URL that exposed externally
